### PR TITLE
feat: 각종 Open Api 관련 클래스, 인터페이스 정의 및 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@
 .externalNativeBuild
 .cxx
 local.properties
-/app/src/main/java/org/konkuk/placelist/data/api/ApiKey.kt

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+/app/src/main/java/org/konkuk/placelist/data/api/ApiKey.kt

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,11 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        Properties properties = new Properties()
+        properties.load(project.rootProject.file('local.properties').newDataInputStream())
+        buildConfigField "String", "KAKAO_API_KEY", "\"${properties.getProperty("KAKAO_API_KEY")}\""
+        buildConfigField "String", "PUBLIC_DATA_SERVICE_KEY", "\"${properties.getProperty("PUBLIC_DATA_SERVICE_KEY")}\""
     }
 
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,4 +45,15 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+
+    implementation 'com.google.android.gms:play-services-location:21.0.1'
+
+    // Retrofit
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    // Converter ( JSON 타입 결과를 객체로 매핑 )
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.11.0'
+
+    // coroutine
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-
+    <!--    background location permission-->
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- internet permission-->
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <!-- internet permission-->
     <uses-permission android:name="android.permission.INTERNET" />
     <application
+        android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/org/konkuk/placelist/GpsConverter.kt
+++ b/app/src/main/java/org/konkuk/placelist/GpsConverter.kt
@@ -1,0 +1,43 @@
+package org.konkuk.placelist
+
+import android.graphics.Point
+
+object GpsConverter {
+
+    // 위경도를 기상청에서 사용하는 격자 좌표로 변환
+    fun dfsXyConv(v1: Double, v2: Double) : Point {
+        val RE = 6371.00877     // 지구 반경(km)
+        val GRID = 5.0          // 격자 간격(km)
+        val SLAT1 = 30.0        // 투영 위도1(degree)
+        val SLAT2 = 60.0        // 투영 위도2(degree)
+        val OLON = 126.0        // 기준점 경도(degree)
+        val OLAT = 38.0         // 기준점 위도(degree)
+        val XO = 43             // 기준점 X좌표(GRID)
+        val YO = 136            // 기준점 Y좌표(GRID)
+        val DEGRAD = Math.PI / 180.0
+        val re = RE / GRID
+        val slat1 = SLAT1 * DEGRAD
+        val slat2 = SLAT2 * DEGRAD
+        val olon = OLON * DEGRAD
+        val olat = OLAT * DEGRAD
+
+        var sn = Math.tan(Math.PI * 0.25 + slat2 * 0.5) / Math.tan(Math.PI * 0.25 + slat1 * 0.5)
+        sn = Math.log(Math.cos(slat1) / Math.cos(slat2)) / Math.log(sn)
+        var sf = Math.tan(Math.PI * 0.25 + slat1 * 0.5)
+        sf = Math.pow(sf, sn) * Math.cos(slat1) / sn
+        var ro = Math.tan(Math.PI * 0.25 + olat * 0.5)
+        ro = re * sf / Math.pow(ro, sn)
+
+        var ra = Math.tan(Math.PI * 0.25 + (v1) * DEGRAD * 0.5)
+        ra = re * sf / Math.pow(ra, sn)
+        var theta = v2 * DEGRAD - olon
+        if (theta > Math.PI) theta -= 2.0 * Math.PI
+        if (theta < -Math.PI) theta += 2.0 * Math.PI
+        theta *= sn
+
+        val x = (ra * Math.sin(theta) + XO + 0.5).toInt()
+        val y = (ro - ra * Math.cos(theta) + YO + 0.5).toInt()
+
+        return Point(x, y)
+    }
+}

--- a/app/src/main/java/org/konkuk/placelist/data/Repository.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/Repository.kt
@@ -1,0 +1,95 @@
+package org.konkuk.placelist.data
+
+import org.konkuk.placelist.data.models.airquality.MeasuredValue
+import org.konkuk.placelist.data.models.monitoringstation.MonitoringStation
+import org.konkuk.placelist.data.models.weatherforecast.WeatherForecast
+import org.konkuk.placelist.data.services.AirKoreaApiService
+import org.konkuk.placelist.data.services.KakaoLocalApiService
+import org.konkuk.placelist.data.services.KmaApiService
+import com.google.gson.GsonBuilder
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import org.konkuk.placelist.BuildConfig
+import org.konkuk.placelist.data.url.Url
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.create
+
+object Repository {
+    var gson = GsonBuilder().setLenient().create()
+
+    suspend fun getNearbyMonitoringStation(latitude: Double, longitude: Double): MonitoringStation? {
+        val tmCoordinates = kakaoLocalApiService.getTmCoordinates(longitude, latitude)
+            .body()
+            ?.documents
+            ?.firstOrNull()
+
+        val tmX = tmCoordinates?.x
+        val tmY = tmCoordinates?.y
+
+        return airKoreaApiService.getNearbyMonitoringStation(tmX!!, tmY!!)
+            .body()
+            ?.response
+            ?.body
+            ?.monitoringStations
+            ?.minByOrNull {
+                it?.tm ?: Double.MAX_VALUE
+            }
+    }
+
+    suspend fun getWeatherForecasts(base_date: String, base_time: String, dataType:  String,  x: Int, y: Int): List<WeatherForecast?>? =
+        kmaApiService.getWeatherForecasts(base_date, base_time,dataType, x, y)
+            .body()
+            ?.response
+            ?.body
+            ?.weatherForecasts
+            ?.weatherForecast
+
+
+    suspend fun getLatestAirQualityData(stationName: String): MeasuredValue?=
+        airKoreaApiService.getRealtimeAirQualities(stationName)
+            .body()
+            ?.response
+            ?.body
+            ?.measuredValues
+            ?.firstOrNull()
+
+    private val kakaoLocalApiService: KakaoLocalApiService by lazy{
+        Retrofit.Builder()
+            .baseUrl(Url.KAKAO_API_BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .client(buildHttpClient())
+            .build()
+            .create()
+    }
+
+    private val airKoreaApiService: AirKoreaApiService by lazy{
+        Retrofit.Builder()
+            .baseUrl(Url.PUBLIC_DATA_BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .client(buildHttpClient())
+            .build()
+            .create()
+    }
+
+    private val kmaApiService: KmaApiService by lazy{
+        Retrofit.Builder()
+            .baseUrl(Url.PUBLIC_DATA_BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .client(buildHttpClient())
+            .build()
+            .create()
+    }
+
+    private fun buildHttpClient(): OkHttpClient =
+        OkHttpClient.Builder()
+            .addInterceptor(
+                HttpLoggingInterceptor().apply {
+                    level = if(BuildConfig.DEBUG) {
+                        HttpLoggingInterceptor.Level.BODY
+                    } else {
+                        HttpLoggingInterceptor.Level.NONE
+                    }
+                }
+            ).build()
+}

--- a/app/src/main/java/org/konkuk/placelist/data/api/ApiKey.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/api/ApiKey.kt
@@ -1,8 +1,0 @@
-package org.konkuk.placelist.data.api
-
-class ApiKey {
-    companion object {
-        const val KAKAO_API_KEY = "f0f91501732f39b9064b5a5faeeb01c6"
-        const val PUBLIC_DATA_SERVICE_KEY = "Xo7w2IXyYqgBiO0WngmEDx%2BrWmMfx9IuLO8HjWL4c32ND51quHcayzSMGULwHAo3StdHTjjmjrO3OxYaTOmnyw%3D%3D"
-    }
-}

--- a/app/src/main/java/org/konkuk/placelist/data/api/ApiKey.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/api/ApiKey.kt
@@ -1,0 +1,8 @@
+package org.konkuk.placelist.data.api
+
+class ApiKey {
+    companion object {
+        const val KAKAO_API_KEY = "f0f91501732f39b9064b5a5faeeb01c6"
+        const val PUBLIC_DATA_SERVICE_KEY = "Xo7w2IXyYqgBiO0WngmEDx%2BrWmMfx9IuLO8HjWL4c32ND51quHcayzSMGULwHAo3StdHTjjmjrO3OxYaTOmnyw%3D%3D"
+    }
+}

--- a/app/src/main/java/org/konkuk/placelist/data/models/airquality/AirQualityResponse.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/airquality/AirQualityResponse.kt
@@ -1,0 +1,8 @@
+package org.konkuk.placelist.data.models.airquality
+
+import com.google.gson.annotations.SerializedName
+
+data class AirQualityResponse(
+    @SerializedName("response")
+    val response: Response?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/airquality/Body.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/airquality/Body.kt
@@ -1,0 +1,8 @@
+package org.konkuk.placelist.data.models.airquality
+
+import com.google.gson.annotations.SerializedName
+
+data class Body(
+    @SerializedName("items")
+    val measuredValues: List<MeasuredValue?>?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/airquality/Header.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/airquality/Header.kt
@@ -1,0 +1,10 @@
+package org.konkuk.placelist.data.models.airquality
+
+import com.google.gson.annotations.SerializedName
+
+data class Header(
+    @SerializedName("resultCode")
+    val resultCode: String?,
+    @SerializedName("resultMsg")
+    val resultMsg: String?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/airquality/MeasuredValue.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/airquality/MeasuredValue.kt
@@ -1,0 +1,58 @@
+package org.konkuk.placelist.data.models.airquality
+
+import com.google.gson.annotations.SerializedName
+
+data class MeasuredValue(
+    @SerializedName("coFlag") // 일산화탄소 플래그
+    val coFlag: Any?,
+    @SerializedName("coGrade") // 일산화탄소 지수
+    val coGrade: String?,
+    @SerializedName("coValue") // 일산화탄소 농도
+    val coValue: String?,
+    @SerializedName("dataTime") // 측정일
+    val dataTime: String?,
+    @SerializedName("khaiGrade") // 통합 대기 환경 지수
+    val khaiGrade: String?,
+    @SerializedName("khaiValue") // 통합 대기 환경 수치
+    val khaiValue: String?,
+    @SerializedName("mangName") // 측정망 정보
+    val mangName: String?,
+    @SerializedName("no2Flag") // 이산화질소 플래그
+    val no2Flag: Any?,
+    @SerializedName("no2Grade") // 이산화질소 지수
+    val no2Grade: String?,
+    @SerializedName("no2Value") // 이산화질소 농도
+    val no2Value: String?,
+    @SerializedName("o3Flag") // 오존 플래그
+    val o3Flag: Any?,
+    @SerializedName("o3Grade") // 오존 지수
+    val o3Grade: String?,
+    @SerializedName("o3Value") // 오존 농도
+    val o3Value: String?,
+    @SerializedName("pm10Flag") // 미세먼지 플래그
+    val pm10Flag: Any?,
+    @SerializedName("pm10Grade") // 미세먼지  24시간 등급
+    val pm10Grade: String?,
+    @SerializedName("pm10Grade1h") // 미세먼지 1시간 등급
+    val pm10Grade1h: String?,
+    @SerializedName("pm10Value") // 미세먼지 농도
+    val pm10Value: String?,
+    @SerializedName("pm10Value24") // 미세먼지 24시간 예측 이동 농도
+    val pm10Value24: String?,
+    @SerializedName("pm25Flag") // 초미세먼지 플래그
+    val pm25Flag: Any?,
+    @SerializedName("pm25Grade") // 초미세먼지  24시간 등급
+    val pm25Grade: String?,
+    @SerializedName("pm25Grade1h") // 초미세먼지 1시간 등급
+    val pm25Grade1h: String?,
+    @SerializedName("pm25Value") // 초미세먼지 농도
+    val pm25Value: String?,
+    @SerializedName("pm25Value24") // 초미세먼지 24시간 예측 이동 농도
+    val pm25Value24: String?,
+    @SerializedName("so2Flag") // 이황산가스 플래그
+    val so2Flag: Any?,
+    @SerializedName("so2Grade") // 이황산가스 지수
+    val so2Grade: String?,
+    @SerializedName("so2Value") // 이황산가수 농도
+    val so2Value: String?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/airquality/Response.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/airquality/Response.kt
@@ -1,0 +1,10 @@
+package org.konkuk.placelist.data.models.airquality
+
+import com.google.gson.annotations.SerializedName
+
+data class Response(
+    @SerializedName("body")
+    val body: Body?,
+    @SerializedName("header")
+    val header: Header?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/monitoringstation/Body.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/monitoringstation/Body.kt
@@ -1,0 +1,8 @@
+package org.konkuk.placelist.data.models.monitoringstation
+
+import com.google.gson.annotations.SerializedName
+
+data class Body(
+    @SerializedName("items")
+    val monitoringStations: List<MonitoringStation?>?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/monitoringstation/Header.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/monitoringstation/Header.kt
@@ -1,0 +1,10 @@
+package org.konkuk.placelist.data.models.monitoringstation
+
+import com.google.gson.annotations.SerializedName
+
+data class Header(
+    @SerializedName("resultCode")
+    val resultCode: String?,
+    @SerializedName("resultMsg")
+    val resultMsg: String?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/monitoringstation/MonitoringStation.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/monitoringstation/MonitoringStation.kt
@@ -1,0 +1,12 @@
+package org.konkuk.placelist.data.models.monitoringstation
+
+import com.google.gson.annotations.SerializedName
+
+data class MonitoringStation(
+    @SerializedName("addr")
+    val addr: String?,
+    @SerializedName("stationName")
+    val stationName: String?,
+    @SerializedName("tm")
+    val tm: Double?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/monitoringstation/MonitoringStationsResponse.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/monitoringstation/MonitoringStationsResponse.kt
@@ -1,0 +1,8 @@
+package org.konkuk.placelist.data.models.monitoringstation
+
+import com.google.gson.annotations.SerializedName
+
+data class MonitoringStationsResponse(
+    @SerializedName("response")
+    val response: Response?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/monitoringstation/Response.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/monitoringstation/Response.kt
@@ -1,0 +1,10 @@
+package org.konkuk.placelist.data.models.monitoringstation
+
+import com.google.gson.annotations.SerializedName
+
+data class Response(
+    @SerializedName("body")
+    val body: Body?,
+    @SerializedName("header")
+    val header: Header?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/tmcoordinates/Document.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/tmcoordinates/Document.kt
@@ -1,0 +1,10 @@
+package org.konkuk.placelist.data.models.tmcoordinates
+
+import com.google.gson.annotations.SerializedName
+
+data class Document(
+    @SerializedName("x")
+    val x: Double?,
+    @SerializedName("y")
+    val y: Double?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/tmcoordinates/Meta.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/tmcoordinates/Meta.kt
@@ -1,0 +1,9 @@
+package org.konkuk.placelist.data.models.tmcoordinates
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Meta(
+    @SerializedName("total_count")
+    val totalCount: Int?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/tmcoordinates/TmCoordinatesResponse.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/tmcoordinates/TmCoordinatesResponse.kt
@@ -1,0 +1,11 @@
+package org.konkuk.placelist.data.models.tmcoordinates
+
+
+import com.google.gson.annotations.SerializedName
+
+data class TmCoordinatesResponse(
+    @SerializedName("documents")
+    val documents: List<Document?>?,
+    @SerializedName("meta")
+    val meta: Meta?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/weatherforecast/Body.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/weatherforecast/Body.kt
@@ -1,0 +1,11 @@
+package org.konkuk.placelist.data.models.weatherforecast
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Body(
+    @SerializedName("dataType")
+    val dataType: String?,
+    @SerializedName("items")
+    val weatherForecasts: WeatherForecasts?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/weatherforecast/Header.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/weatherforecast/Header.kt
@@ -1,0 +1,11 @@
+package org.konkuk.placelist.data.models.weatherforecast
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Header(
+    @SerializedName("resultCode")
+    val resultCode: String?,
+    @SerializedName("resultMsg")
+    val resultMsg: String?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/weatherforecast/Response.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/weatherforecast/Response.kt
@@ -1,0 +1,11 @@
+package org.konkuk.placelist.data.models.weatherforecast
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Response(
+    @SerializedName("body")
+    val body: Body?,
+    @SerializedName("header")
+    val header: Header?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/weatherforecast/WeatherForecast.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/weatherforecast/WeatherForecast.kt
@@ -1,0 +1,23 @@
+package org.konkuk.placelist.data.models.weatherforecast
+
+
+import com.google.gson.annotations.SerializedName
+
+data class WeatherForecast(
+    @SerializedName("baseDate")
+    val baseDate: String?,
+    @SerializedName("baseTime")
+    val baseTime: String?,
+    @SerializedName("category")
+    val category: String?,
+    @SerializedName("fcstDate")
+    val fcstDate: String?,
+    @SerializedName("fcstTime")
+    val fcstTime: String?,
+    @SerializedName("fcstValue")
+    val fcstValue: String?,
+    @SerializedName("nx")
+    val nx: Int?,
+    @SerializedName("ny")
+    val ny: Int?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/weatherforecast/WeatherForecastResponse.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/weatherforecast/WeatherForecastResponse.kt
@@ -1,0 +1,9 @@
+package org.konkuk.placelist.data.models.weatherforecast
+
+
+import com.google.gson.annotations.SerializedName
+
+data class WeatherForecastResponse(
+    @SerializedName("response")
+    val response: Response?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/models/weatherforecast/WeatherForecasts.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/models/weatherforecast/WeatherForecasts.kt
@@ -1,0 +1,9 @@
+package org.konkuk.placelist.data.models.weatherforecast
+
+
+import com.google.gson.annotations.SerializedName
+
+data class WeatherForecasts(
+    @SerializedName("item")
+    val weatherForecast: List<WeatherForecast?>?
+)

--- a/app/src/main/java/org/konkuk/placelist/data/services/AirKoreaApiService.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/services/AirKoreaApiService.kt
@@ -1,6 +1,7 @@
 package org.konkuk.placelist.data.services
 
-import org.konkuk.placelist.data.api.ApiKey.Companion.PUBLIC_DATA_SERVICE_KEY
+import org.konkuk.placelist.BuildConfig
+import org.konkuk.placelist.BuildConfig.PUBLIC_DATA_SERVICE_KEY
 import org.konkuk.placelist.data.models.airquality.AirQualityResponse
 import org.konkuk.placelist.data.models.monitoringstation.MonitoringStationsResponse
 import retrofit2.Response

--- a/app/src/main/java/org/konkuk/placelist/data/services/AirKoreaApiService.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/services/AirKoreaApiService.kt
@@ -1,0 +1,28 @@
+package org.konkuk.placelist.data.services
+
+import org.konkuk.placelist.data.api.ApiKey.Companion.PUBLIC_DATA_SERVICE_KEY
+import org.konkuk.placelist.data.models.airquality.AirQualityResponse
+import org.konkuk.placelist.data.models.monitoringstation.MonitoringStationsResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface AirKoreaApiService {
+
+    @GET("B552584/MsrstnInfoInqireSvc/getNearbyMsrstnList" +
+            "?serviceKey=${PUBLIC_DATA_SERVICE_KEY}" +
+            "&returnType=json")
+    suspend fun getNearbyMonitoringStation(
+        @Query("tmX") tmX: Double,
+        @Query("tmY") tmY: Double
+    ): Response<MonitoringStationsResponse>
+
+    @GET("B552584/ArpltnInforInqireSvc/getMsrstnAcctoRltmMesureDnsty" +
+            "?serviceKey=${PUBLIC_DATA_SERVICE_KEY}" +
+            "&returnType=json" +
+            "&dataTerm=DAILY" +
+            "&ver=1.3")
+    suspend fun getRealtimeAirQualities(
+        @Query("stationName") stationName: String
+    ): Response<AirQualityResponse>
+}

--- a/app/src/main/java/org/konkuk/placelist/data/services/KakaoLocalApiService.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/services/KakaoLocalApiService.kt
@@ -1,0 +1,18 @@
+package org.konkuk.placelist.data.services
+
+import org.konkuk.placelist.data.api.ApiKey.Companion.KAKAO_API_KEY
+import org.konkuk.placelist.data.models.tmcoordinates.TmCoordinatesResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.Query
+
+interface KakaoLocalApiService {
+
+    @Headers("Authorization: KakaoAK $KAKAO_API_KEY")
+    @GET("v2/local/geo/transcoord.json?output_coord=TM")
+    suspend fun getTmCoordinates(
+        @Query("x") longitude: Double,
+        @Query("y") latitude: Double
+    ): Response<TmCoordinatesResponse>
+}

--- a/app/src/main/java/org/konkuk/placelist/data/services/KakaoLocalApiService.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/services/KakaoLocalApiService.kt
@@ -1,6 +1,6 @@
 package org.konkuk.placelist.data.services
 
-import org.konkuk.placelist.data.api.ApiKey.Companion.KAKAO_API_KEY
+import org.konkuk.placelist.BuildConfig.KAKAO_API_KEY
 import org.konkuk.placelist.data.models.tmcoordinates.TmCoordinatesResponse
 import retrofit2.Response
 import retrofit2.http.GET

--- a/app/src/main/java/org/konkuk/placelist/data/services/KmaApiService.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/services/KmaApiService.kt
@@ -1,6 +1,6 @@
 package org.konkuk.placelist.data.services
 
-import org.konkuk.placelist.data.api.ApiKey.Companion.PUBLIC_DATA_SERVICE_KEY
+import org.konkuk.placelist.BuildConfig.PUBLIC_DATA_SERVICE_KEY
 import org.konkuk.placelist.data.models.weatherforecast.WeatherForecastResponse
 import retrofit2.Response
 import retrofit2.http.GET

--- a/app/src/main/java/org/konkuk/placelist/data/services/KmaApiService.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/services/KmaApiService.kt
@@ -1,0 +1,19 @@
+package org.konkuk.placelist.data.services
+
+import org.konkuk.placelist.data.api.ApiKey.Companion.PUBLIC_DATA_SERVICE_KEY
+import org.konkuk.placelist.data.models.weatherforecast.WeatherForecastResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface KmaApiService {
+
+    @GET("1360000/VilageFcstInfoService_2.0/getVilageFcst" + "?serviceKey=${PUBLIC_DATA_SERVICE_KEY}" + "&returnType=json" + "&numOfRows=200")
+    suspend fun getWeatherForecasts(
+        @Query("base_date") base_date: String,
+        @Query("base_time") base_time: String,
+        @Query("dataType") dataType: String,
+        @Query("nx") x: Int,
+        @Query("ny") y: Int
+    ): Response<WeatherForecastResponse>
+}

--- a/app/src/main/java/org/konkuk/placelist/data/url/Url.kt
+++ b/app/src/main/java/org/konkuk/placelist/data/url/Url.kt
@@ -1,0 +1,8 @@
+package org.konkuk.placelist.data.url
+
+class Url {
+    companion object {
+        const val KAKAO_API_BASE_URL = "https://dapi.kakao.com/"
+        const val PUBLIC_DATA_BASE_URL = "http://apis.data.go.kr/"
+    }
+}


### PR DESCRIPTION
#4 
날씨 정보를 받아오기 위해 이용한 Open Api는 다음과 같습니다.

카카오 로컬 api: 위도, 경도를 tm 좌표계로 변환
에어코리아_측정소정보 api: 요청한 tm 좌표 주변 측정소 정보 조회
에어코리아_대기오염정보 api: 측정소별 실시간 대기오염 측정 정보 조회
기상청_단기예보 api: 단기예보 정보 조회

api key는 일단 ApiKey 클래스 안에서 전역변수로 접근할 수 있게 해두었습니다. 
.gitignore에 해당 클래스를 입력하면 보안성 문제를 해결할 수 있다고 알고 있는데 잘못되었거나 더 좋은 방법이 있다면 알려주시면 좋을 것 같습니다. (해당 PR에서는 아직 gitignore에 포함하지 않은 상태입니다)

새로 추가한 dependency로는 retrofit2, converter-gson, coroutine, google play-services-location이 있습니다.

또한 다음과 같은 객체 클래스를 구현하였습니다.
Repository: 클래스에서 해당 객체를 통해 api 호출 가능
GpsConverter: 위도, 경도를 기상청에서 사용하는 격자 좌표로 변환