### PR TITLE
feat: 날씨 알림 받기 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,10 @@ dependencies {
     implementation 'androidx.preference:preference-ktx:1.1.1'
     implementation 'com.google.android.gms:play-services-location:18.0.0'
 
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.11.0'
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,8 +6,11 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
+        android:usesCleartextTraffic="true"
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:enableOnBackInvokedCallback="true"
@@ -18,8 +21,15 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.PlaceList"
         tools:targetApi="31">
-        <activity android:name=".setting.SettingsActivity"
-            android:exported="false"/>
+        <receiver
+            android:name=".weather.WeatherAlarmReceiver"
+            android:enabled="true"
+            android:exported="true">
+        </receiver>
+
+        <activity
+            android:name=".setting.SettingsActivity"
+            android:exported="false" />
         <activity
             android:name=".place.PlacesActivity"
             android:exported="false" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <application
         android:usesCleartextTraffic="true"
@@ -25,6 +26,9 @@
             android:name=".weather.WeatherAlarmReceiver"
             android:enabled="true"
             android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"></action>
+            </intent-filter>
         </receiver>
 
         <activity

--- a/app/src/main/java/org/konkuk/placelist/main/MainActivity.kt
+++ b/app/src/main/java/org/konkuk/placelist/main/MainActivity.kt
@@ -72,11 +72,17 @@ class MainActivity : AppCompatActivity(), AddPlaceListener {
         val prefs = PreferenceManager.getDefaultSharedPreferences(this)
         val alarmOnOff = prefs.getBoolean("weatherAlarm", true)
 
+        val hour = prefs.getString("hour", "6")
+        val minute = prefs.getString("minute", "0")
+
         val pendingIntent = Intent(this, WeatherAlarmReceiver::class.java).let {
             it.putExtra("code", 1000)
+            it.putExtra("hour", hour)
+            it.putExtra("minute",minute)
             PendingIntent.getBroadcast(this, 1000, it, PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE)
         }
         val alarmManager = this.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             if(!alarmManager.canScheduleExactAlarms()) {
                 Intent().also {
@@ -87,8 +93,6 @@ class MainActivity : AppCompatActivity(), AddPlaceListener {
         }
 
         if(alarmOnOff) {
-            val hour = prefs.getString("hour", "6")
-            val minute = prefs.getString("minute", "0")
             val calendar = Calendar.getInstance().apply{
                 timeInMillis = System.currentTimeMillis()
                 set(Calendar.HOUR_OF_DAY, hour!!.toInt())
@@ -98,6 +102,7 @@ class MainActivity : AppCompatActivity(), AddPlaceListener {
             if(calendar.before(Calendar.getInstance())) {
                 calendar.add(Calendar.DATE, 1)
             }
+            //alarmManager.setRepeating(AlarmManager.RTC_WAKEUP, calendar.timeInMillis, AlarmManager.INTERVAL_DAY, pendingIntent)
             alarmManager.setExactAndAllowWhileIdle(
                 AlarmManager.RTC_WAKEUP, calendar.timeInMillis, pendingIntent
             )

--- a/app/src/main/java/org/konkuk/placelist/main/MainActivity.kt
+++ b/app/src/main/java/org/konkuk/placelist/main/MainActivity.kt
@@ -106,10 +106,10 @@ class MainActivity : AppCompatActivity(), AddPlaceListener {
             alarmManager.setExactAndAllowWhileIdle(
                 AlarmManager.RTC_WAKEUP, calendar.timeInMillis, pendingIntent
             )
-            Toast.makeText(this, "set Alarm on $hour : $minute", Toast.LENGTH_SHORT).show()
+            //Toast.makeText(this, "set Alarm on $hour : $minute", Toast.LENGTH_SHORT).show()
         } else {
             alarmManager.cancel(pendingIntent)
-            Toast.makeText(this, "set Alarm off", Toast.LENGTH_SHORT).show()
+            //Toast.makeText(this, "set Alarm off", Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/java/org/konkuk/placelist/main/MainActivity.kt
+++ b/app/src/main/java/org/konkuk/placelist/main/MainActivity.kt
@@ -1,5 +1,6 @@
 package org.konkuk.placelist.main
 
+import android.Manifest
 import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
@@ -8,17 +9,26 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.Looper
 import android.provider.Settings
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
+import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.LocationSettingsRequest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -52,6 +62,8 @@ class MainActivity : AppCompatActivity(), AddPlaceListener {
         super.onStart()
         if(this::placeAdapter.isInitialized) placeAdapter.refresh()
     }
+
+
     private fun initSettings() {
         val prefs = PreferenceManager.getDefaultSharedPreferences(this)
 

--- a/app/src/main/java/org/konkuk/placelist/setting/SetTimeDialogFragment.kt
+++ b/app/src/main/java/org/konkuk/placelist/setting/SetTimeDialogFragment.kt
@@ -35,8 +35,8 @@ class SetTimeDialogFragment : DialogFragment() {
         act = context as SettingsActivity
         prefs = PreferenceManager.getDefaultSharedPreferences(act)
 
-        val hour = prefs?.getString("notification_hour", "6").toString()
-        val minute = prefs?.getString("notification_minute", "0").toString()
+        val hour = prefs?.getString("hour", "6").toString()
+        val minute = prefs?.getString("minute", "0").toString()
 
         val isSystem24Hour = DateFormat.is24HourFormat(context)
 
@@ -54,8 +54,8 @@ class SetTimeDialogFragment : DialogFragment() {
             }
             submitBtn.setOnClickListener {
                 prefs!!.edit()
-                    .putString("notification_hour", "${timePicker.hour}")
-                    .putString("notification_minute", "${timePicker.minute}")
+                    .putString("hour", "${timePicker.hour}")
+                    .putString("minute", "${timePicker.minute}")
                     .apply()
                 dismiss()
             }

--- a/app/src/main/java/org/konkuk/placelist/setting/SettingsActivity.kt
+++ b/app/src/main/java/org/konkuk/placelist/setting/SettingsActivity.kt
@@ -62,16 +62,18 @@ class SettingsActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferen
     }
 
     private fun setWeatherAlarm(prefs: SharedPreferences?) {
+        val hour = prefs!!.getString("hour", "6")
+        val minute = prefs!!.getString("minute", "0")
         val pendingIntent = Intent(this, WeatherAlarmReceiver::class.java).let {
             it.putExtra("code", 1000)
+            it.putExtra("hour", hour)
+            it.putExtra("minute",minute)
             PendingIntent.getBroadcast(this, 1000, it, PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE)
         }
         val alarmManager = this.getSystemService(Context.ALARM_SERVICE) as AlarmManager
         val alarmOnOff = prefs!!.getBoolean("weatherAlarm", true)
 
         if(alarmOnOff) {
-            val hour = prefs.getString("hour", "6")
-            val minute = prefs.getString("minute", "0")
             val calendar = Calendar.getInstance().apply{
                 timeInMillis = System.currentTimeMillis()
                 set(Calendar.HOUR_OF_DAY, hour!!.toInt())
@@ -81,6 +83,7 @@ class SettingsActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferen
             if(calendar.before(Calendar.getInstance())) {
                 calendar.add(Calendar.DATE, 1)
             }
+            //alarmManager.setRepeating(AlarmManager.RTC_WAKEUP, calendar.timeInMillis, AlarmManager.INTERVAL_DAY, pendingIntent)
             alarmManager.setExactAndAllowWhileIdle(
                 AlarmManager.RTC_WAKEUP, calendar.timeInMillis, pendingIntent
             )

--- a/app/src/main/java/org/konkuk/placelist/setting/SettingsActivity.kt
+++ b/app/src/main/java/org/konkuk/placelist/setting/SettingsActivity.kt
@@ -1,12 +1,21 @@
 package org.konkuk.placelist.setting
 
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
+import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
 import org.konkuk.placelist.R
+import org.konkuk.placelist.weather.WeatherAlarmReceiver
+import java.util.*
 
 class SettingsActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceChangeListener {
 
@@ -29,7 +38,7 @@ class SettingsActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferen
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             setPreferencesFromResource(R.xml.root_preferences, rootKey)
 
-            val preference = preferenceManager.findPreference<Preference>("weather_notification")
+            val preference = preferenceManager.findPreference<Preference>("weatherTimer")
             preference?.setOnPreferenceClickListener {
 
                 val act = context as SettingsActivity
@@ -41,8 +50,45 @@ class SettingsActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferen
 
     }
 
-    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
+    override fun onSharedPreferenceChanged(prefs: SharedPreferences?, key: String?) {
+        when(key) {
+            "hour", "minute" -> {
+                setWeatherAlarm(prefs)
+            }
+            "weatherAlarm" -> {
+                setWeatherAlarm(prefs)
+            }
+        }
+    }
 
+    private fun setWeatherAlarm(prefs: SharedPreferences?) {
+        val pendingIntent = Intent(this, WeatherAlarmReceiver::class.java).let {
+            it.putExtra("code", 1000)
+            PendingIntent.getBroadcast(this, 1000, it, PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        }
+        val alarmManager = this.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val alarmOnOff = prefs!!.getBoolean("weatherAlarm", true)
+
+        if(alarmOnOff) {
+            val hour = prefs.getString("hour", "6")
+            val minute = prefs.getString("minute", "0")
+            val calendar = Calendar.getInstance().apply{
+                timeInMillis = System.currentTimeMillis()
+                set(Calendar.HOUR_OF_DAY, hour!!.toInt())
+                set(Calendar.MINUTE, minute!!.toInt())
+            }
+            //이미 지난 시간 설정한 경우 다음날 같은 시간으로 설정
+            if(calendar.before(Calendar.getInstance())) {
+                calendar.add(Calendar.DATE, 1)
+            }
+            alarmManager.setExactAndAllowWhileIdle(
+                AlarmManager.RTC_WAKEUP, calendar.timeInMillis, pendingIntent
+            )
+            Toast.makeText(this, "set Alarm on $hour : $minute", Toast.LENGTH_SHORT).show()
+        } else {
+            alarmManager.cancel(pendingIntent)
+            Toast.makeText(this, "set Alarm off", Toast.LENGTH_SHORT).show()
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/org/konkuk/placelist/setting/SettingsActivity.kt
+++ b/app/src/main/java/org/konkuk/placelist/setting/SettingsActivity.kt
@@ -87,10 +87,10 @@ class SettingsActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferen
             alarmManager.setExactAndAllowWhileIdle(
                 AlarmManager.RTC_WAKEUP, calendar.timeInMillis, pendingIntent
             )
-            Toast.makeText(this, "set Alarm on $hour : $minute", Toast.LENGTH_SHORT).show()
+            //Toast.makeText(this, "set Alarm on $hour : $minute", Toast.LENGTH_SHORT).show()
         } else {
             alarmManager.cancel(pendingIntent)
-            Toast.makeText(this, "set Alarm off", Toast.LENGTH_SHORT).show()
+            //Toast.makeText(this, "set Alarm off", Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/java/org/konkuk/placelist/weather/Repository.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/Repository.kt
@@ -1,0 +1,95 @@
+package org.konkuk.placelist.weather
+
+import com.google.gson.GsonBuilder
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import org.konkuk.placelist.BuildConfig
+import org.konkuk.placelist.weather.models.airquality.MeasuredValue
+import org.konkuk.placelist.weather.models.monitoringstation.MonitoringStation
+import org.konkuk.placelist.weather.models.weatherforecast.WeatherForecast
+import org.konkuk.placelist.weather.`object`.Url
+import org.konkuk.placelist.weather.services.AirKoreaApiService
+import org.konkuk.placelist.weather.services.KakaoLocalApiService
+import org.konkuk.placelist.weather.services.KmaApiService
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.create
+
+object Repository {
+    var gson = GsonBuilder().setLenient().create()
+
+    suspend fun getNearbyMonitoringStation(latitude: Double, longitude: Double): MonitoringStation? {
+        val tmCoordinates = kakaoLocalApiService.getTmCoordinates(longitude, latitude)
+            .body()
+            ?.documents
+            ?.firstOrNull()
+
+        val tmX = tmCoordinates?.x
+        val tmY = tmCoordinates?.y
+
+        return airKoreaApiService.getNearbyMonitoringStation(tmX!!, tmY!!)
+            .body()
+            ?.response
+            ?.body
+            ?.monitoringStations
+            ?.minByOrNull {
+                it?.tm ?: Double.MAX_VALUE
+            }
+    }
+
+    suspend fun getWeatherForecasts(base_date: String, base_time: String, dataType:  String,  x: Int, y: Int): List<WeatherForecast?>? =
+        kmaApiService.getWeatherForecasts(base_date, base_time,dataType, x, y)
+            .body()
+            ?.response
+            ?.body
+            ?.weatherForecasts
+            ?.weatherForecast
+
+
+    suspend fun getLatestAirQualityData(stationName: String): MeasuredValue?=
+        airKoreaApiService.getRealtimeAirQualities(stationName)
+            .body()
+            ?.response
+            ?.body
+            ?.measuredValues
+            ?.firstOrNull()
+
+    private val kakaoLocalApiService: KakaoLocalApiService by lazy{
+        Retrofit.Builder()
+            .baseUrl(Url.KAKAO_API_BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .client(buildHttpClient())
+            .build()
+            .create()
+    }
+
+    private val airKoreaApiService: AirKoreaApiService by lazy{
+        Retrofit.Builder()
+            .baseUrl(Url.PUBLIC_DATA_BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .client(buildHttpClient())
+            .build()
+            .create()
+    }
+
+    private val kmaApiService: KmaApiService by lazy{
+        Retrofit.Builder()
+            .baseUrl(Url.PUBLIC_DATA_BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .client(buildHttpClient())
+            .build()
+            .create()
+    }
+
+    private fun buildHttpClient(): OkHttpClient =
+        OkHttpClient.Builder()
+            .addInterceptor(
+                HttpLoggingInterceptor().apply {
+                    level = if(BuildConfig.DEBUG) {
+                        HttpLoggingInterceptor.Level.BODY
+                    } else {
+                        HttpLoggingInterceptor.Level.NONE
+                    }
+                }
+            ).build()
+}

--- a/app/src/main/java/org/konkuk/placelist/weather/WeatherAlarmReceiver.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/WeatherAlarmReceiver.kt
@@ -1,0 +1,215 @@
+package org.konkuk.placelist.weather
+
+import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.graphics.Color
+import android.os.Build
+import android.renderscript.RenderScript
+import android.util.Log
+import android.widget.Toast
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat.getSystemService
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.tasks.CancellationTokenSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.konkuk.placelist.R
+import org.konkuk.placelist.main.MainActivity
+import org.konkuk.placelist.weather.models.airquality.MeasuredValue
+import org.konkuk.placelist.weather.models.weatherforecast.WeatherForecast
+import org.konkuk.placelist.weather.models.weatherforecast.WeatherForecasts
+import org.konkuk.placelist.weather.`object`.GpsConverter
+import java.text.SimpleDateFormat
+import java.util.*
+import kotlin.collections.ArrayList
+
+class WeatherAlarmReceiver : BroadcastReceiver() {
+
+    private lateinit var fusedLocationProviderClient: FusedLocationProviderClient
+    private var cancellationTokenSource: CancellationTokenSource? = null
+    private val scope = MainScope()
+
+    var measuredValue: MeasuredValue? = null
+    private var weatherForecasts: List<WeatherForecast?>? = null
+    lateinit var stationName: String
+
+    lateinit var cal: Calendar
+    lateinit var baseDate: String
+    lateinit var baseTime: String
+
+    override fun onReceive(context: Context, intent: Intent) {
+
+        if (intent.getIntExtra("code", 0) == 1000) {
+            Toast.makeText(context, "alarm ring", Toast.LENGTH_SHORT).show()
+            fetchWeatherData(context)
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun fetchWeatherData(context: Context) {
+        cancellationTokenSource = CancellationTokenSource()
+        fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(context)
+        fusedLocationProviderClient.getCurrentLocation(
+            LocationRequest.PRIORITY_HIGH_ACCURACY,
+            cancellationTokenSource!!.token
+        )
+            .addOnSuccessListener { location ->
+                scope.launch {
+                    val monitoringStation =
+                        Repository.getNearbyMonitoringStation(location.latitude, location.longitude)
+                    measuredValue =
+                        Repository.getLatestAirQualityData(monitoringStation!!.stationName!!)
+                    stationName = monitoringStation.stationName.toString()
+
+                    Log.d("weather", measuredValue?.o3Grade.toString())
+                    Log.d("weather", measuredValue?.pm10Grade.toString())
+                    Log.d("weather", measuredValue?.pm25Grade.toString())
+
+                    setBaseTime()
+
+                    val curPoint = GpsConverter.dfsXyConv(location.latitude, location.longitude)
+                    weatherForecasts = Repository.getWeatherForecasts(
+                        baseDate,
+                        baseTime,
+                        "JSON",
+                        curPoint.x,
+                        curPoint.y
+                    )
+                    withContext(Dispatchers.Main) {
+                        makeNotification(context)
+                    }
+                }
+            }
+    }
+
+    private fun makeNotification(context: Context) {
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channelId = "날씨 알림"
+            val channelName = "PlaceList"
+            val notificationChannel =
+                NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_DEFAULT)
+                    .apply{
+                        enableLights(true)
+                        lightColor = Color.BLUE
+                        lockscreenVisibility = Notification.VISIBILITY_PRIVATE
+                    }
+
+            val intent = Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
+            val pendingIntent: PendingIntent = PendingIntent.getActivity(context, 1000, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+
+            val notificationBuilder = NotificationCompat.Builder(context, channelId)
+                .setContentTitle("날씨 알림")
+                .setContentText("$stationName 예보 확인하기")
+                .setSmallIcon(R.drawable.baseline_alarm_24)
+                .setAutoCancel(true)
+                .setContentIntent(pendingIntent)
+                .setStyle(
+                    NotificationCompat.BigTextStyle()
+                    .bigText(getWeatherForecastMsg()))
+            val notification = notificationBuilder.build()
+            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.apply {
+                createNotificationChannel(notificationChannel)
+                notify(0, notification)
+            }
+        }
+    }
+
+    private fun getWeatherForecastMsg(): CharSequence? {
+        var msg = ""
+        weatherForecasts?.forEach {
+            //PTY: 강수정보
+            if (it?.category == "PTY") {
+                when (it?.fcstValue) {
+                    "1" -> {
+                        msg += getPtyMsg(it?.fcstDate, it?.fcstTime, "비")
+                        return@forEach
+                    }
+                    "2" -> {
+                        msg += getPtyMsg(it?.fcstDate, it?.fcstTime, "비/눈")
+                        return@forEach
+                    }
+                    "3" -> {
+                        msg += getPtyMsg(it?.fcstDate, it?.fcstTime, "눈")
+                        return@forEach
+                    }
+                    "4" -> {
+                        msg += getPtyMsg(it?.fcstDate, it?.fcstTime, "소나기")
+                        return@forEach
+                    }
+                }
+            }
+        }
+        msg += "오존 등급: ${measuredValue?.o3Grade.toString()}\n" +
+                "미세먼지 등급: ${measuredValue?.pm10Grade.toString()}\n" +
+                "초미세먼지 등급: ${measuredValue?.pm10Grade.toString()}\n"
+        return msg
+    }
+
+    private fun getPtyMsg(fcstDate: String?, fcstTime: String?, pty: String): String{
+        val today = if(fcstDate == getDate()) { "오늘" } else { "내일" }
+        return "$today ${fcstTime}시에 $pty 예보가 있어요."
+    }
+
+    private fun getDate(): String {
+        val date = Date(System.currentTimeMillis())
+        val dataFormat = SimpleDateFormat("yyyyMMdd")
+        return dataFormat.format(date)
+    }
+
+    private fun setBaseTime() {
+        cal = Calendar.getInstance()
+
+        when (SimpleDateFormat("HH", Locale.getDefault()).format(cal.time)) {
+            "00", "01" -> {
+                cal.add(Calendar.DATE, -1).toString()
+                baseTime = "2300"
+            }
+            "02", "03", "04" -> {
+                cal = Calendar.getInstance()
+                baseTime = "0200"
+            }
+            "05", "06", "07" -> {
+                cal = Calendar.getInstance()
+                baseTime = "0500"
+            }
+            "08", "09", "10" -> {
+                cal = Calendar.getInstance()
+                baseTime = "0800"
+            }
+            "11", "12", "13" -> {
+                cal = Calendar.getInstance()
+                baseTime = "1100"
+            }
+            "14", "15", "16" -> {
+                cal = Calendar.getInstance()
+                baseTime = "1400"
+            }
+            "17", "18", "19" -> {
+                cal = Calendar.getInstance()
+                baseTime = "1700"
+            }
+            "20", "21", "22" -> {
+                cal = Calendar.getInstance()
+                baseTime = "2000"
+            }
+            "23" -> {
+                cal = Calendar.getInstance()
+                baseTime = "2300"
+            }
+        }
+        baseDate = SimpleDateFormat("yyyyMMdd", Locale.getDefault()).format(cal.time)
+    }
+}

--- a/app/src/main/java/org/konkuk/placelist/weather/WeatherAlarmReceiver.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/WeatherAlarmReceiver.kt
@@ -201,12 +201,6 @@ class WeatherAlarmReceiver : BroadcastReceiver() {
             )
         }
 
-        val calendar = Calendar.getInstance().apply {
-            timeInMillis = System.currentTimeMillis()
-            set(Calendar.HOUR_OF_DAY, hour!!.toInt())
-            set(Calendar.MINUTE, minute!!.toInt())
-        }
-
         alarmManager.setExactAndAllowWhileIdle(
             AlarmManager.ELAPSED_REALTIME_WAKEUP,
             SystemClock.elapsedRealtime() + AlarmManager.INTERVAL_DAY,

--- a/app/src/main/java/org/konkuk/placelist/weather/WeatherAlarmReceiver.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/WeatherAlarmReceiver.kt
@@ -1,23 +1,21 @@
 package org.konkuk.placelist.weather
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.app.*
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.Color
 import android.os.Build
+import android.os.Looper
 import android.os.SystemClock
-import android.provider.Settings
-import android.renderscript.RenderScript
 import android.util.Log
-import android.widget.Toast
+import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
-import androidx.core.content.ContextCompat.getSystemService
 import androidx.preference.PreferenceManager
-import com.google.android.gms.location.FusedLocationProviderClient
-import com.google.android.gms.location.LocationRequest
-import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.*
 import com.google.android.gms.tasks.CancellationTokenSource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
@@ -27,11 +25,9 @@ import org.konkuk.placelist.R
 import org.konkuk.placelist.main.MainActivity
 import org.konkuk.placelist.weather.models.airquality.MeasuredValue
 import org.konkuk.placelist.weather.models.weatherforecast.WeatherForecast
-import org.konkuk.placelist.weather.models.weatherforecast.WeatherForecasts
 import org.konkuk.placelist.weather.`object`.GpsConverter
 import java.text.SimpleDateFormat
 import java.util.*
-import kotlin.collections.ArrayList
 
 class WeatherAlarmReceiver : BroadcastReceiver() {
 
@@ -50,22 +46,28 @@ class WeatherAlarmReceiver : BroadcastReceiver() {
     private var hour: String? = null
     private var minute: String? = null
 
+
+    lateinit var locationRequest: LocationRequest
+    lateinit var locationCallback: LocationCallback
+    var startupdate = false
+    var pFlag = false
+
     override fun onReceive(context: Context, intent: Intent) {
 
         if (intent.getIntExtra("code", 0) == 1000) {
             Log.d("weatherAlarmReceiver", "alarm Ring")
             hour = intent.getStringExtra("hour")
             minute = intent.getStringExtra("minute")
-            fetchWeatherData(context)
+            getLocation(context)
         }
 
-        if(intent.action == "android.intent.action.BOOT_COMPLETED") {
+        if (intent.action == "android.intent.action.BOOT_COMPLETED") {
             setAlarm(context)
         }
     }
 
     @SuppressLint("MissingPermission")
-    private fun fetchWeatherData(context: Context) {
+    private fun getLocation(context: Context) {
         cancellationTokenSource = CancellationTokenSource()
         fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(context)
         fusedLocationProviderClient.getCurrentLocation(
@@ -73,33 +75,85 @@ class WeatherAlarmReceiver : BroadcastReceiver() {
             cancellationTokenSource!!.token
         )
             .addOnSuccessListener { location ->
-                scope.launch {
-                    val monitoringStation =
-                        Repository.getNearbyMonitoringStation(location.latitude, location.longitude)
-                    measuredValue =
-                        Repository.getLatestAirQualityData(monitoringStation!!.stationName!!)
-                    stationName = monitoringStation.stationName.toString()
-
-                    Log.d("weather", measuredValue?.o3Grade.toString())
-                    Log.d("weather", measuredValue?.pm10Grade.toString())
-                    Log.d("weather", measuredValue?.pm25Grade.toString())
-
-                    setBaseTime()
-
-                    val curPoint = GpsConverter.dfsXyConv(location.latitude, location.longitude)
-                    weatherForecasts = Repository.getWeatherForecasts(
-                        baseDate,
-                        baseTime,
-                        "JSON",
-                        curPoint.x,
-                        curPoint.y
-                    )
-                    withContext(Dispatchers.Main) {
-                        makeNotification(context)
-                        setNextAlarm(context)
-                    }
+                if (location == null) {
+                    initLocation(context)
+                }
+                else {
+                    fetchWeatherData(context, location.longitude, location.latitude)
                 }
             }
+    }
+
+    private fun fetchWeatherData(context: Context, latitude:Double, longitude: Double) {
+        scope.launch {
+            val monitoringStation =
+                Repository.getNearbyMonitoringStation(latitude, longitude)
+            measuredValue =
+                Repository.getLatestAirQualityData(monitoringStation!!.stationName!!)
+            stationName = monitoringStation.stationName.toString()
+
+            Log.d("weather", measuredValue?.o3Grade.toString())
+            Log.d("weather", measuredValue?.pm10Grade.toString())
+            Log.d("weather", measuredValue?.pm25Grade.toString())
+
+            setBaseTime()
+
+            val curPoint = GpsConverter.dfsXyConv(latitude, longitude)
+            weatherForecasts = Repository.getWeatherForecasts(
+                baseDate,
+                baseTime,
+                "JSON",
+                curPoint.x,
+                curPoint.y
+            )
+            withContext(Dispatchers.Main) {
+                makeNotification(context)
+                setNextAlarm(context)
+                stopLocationUpdate()
+            }
+        }
+    }
+    private fun initLocation(context: Context) {
+        locationRequest = LocationRequest.create().apply {
+            interval = 1000 * 60 * 60
+            fastestInterval = 1000 * 5
+            priority = LocationRequest.PRIORITY_HIGH_ACCURACY
+        }
+        //val builder = LocationSettingsRequest.Builder().addLocationRequest(locationRequest)
+        locationCallback = object : LocationCallback() {
+            override fun onLocationResult(location: LocationResult) {
+                if(location.locations.size == 0) {
+                    Log.d("weatherAlarmReceiver", "위치 요청 실패")
+                    return
+                }
+                Log.d("locationRequest", location.locations[location.locations.size - 1].latitude.toString() + " " + location.locations[location.locations.size - 1].longitude.toString())
+                fetchWeatherData(context, location.locations[location.locations.size - 1].latitude, location.locations[location.locations.size - 1].longitude)
+            }
+        }
+        startLocationUpdate(context)
+    }
+
+    private fun startLocationUpdate(context: Context) {
+        if (ActivityCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            return
+        }
+        startupdate = true
+        fusedLocationProviderClient.requestLocationUpdates(
+            locationRequest, locationCallback, Looper.getMainLooper()
+        )
+        Log.d("locationUpdate", "startLocationUpdates()")
+
+    }
+    private fun stopLocationUpdate() {
+        fusedLocationProviderClient.removeLocationUpdates(locationCallback)
+        startupdate=false
     }
 
     private fun setNextAlarm(context: Context) {
@@ -107,29 +161,36 @@ class WeatherAlarmReceiver : BroadcastReceiver() {
         val pendingIntent = Intent(context, WeatherAlarmReceiver::class.java).let {
             it.putExtra("code", 1000)
             it.putExtra("hour", hour)
-            it.putExtra("minute",minute)
-            PendingIntent.getBroadcast(context, 1000, it, PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            it.putExtra("minute", minute)
+            PendingIntent.getBroadcast(
+                context,
+                1000,
+                it,
+                PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
         }
 
-        val calendar = Calendar.getInstance().apply{
+        val calendar = Calendar.getInstance().apply {
             timeInMillis = System.currentTimeMillis()
             set(Calendar.HOUR_OF_DAY, hour!!.toInt())
             set(Calendar.MINUTE, minute!!.toInt())
         }
 
         alarmManager.setExactAndAllowWhileIdle(
-            AlarmManager.ELAPSED_REALTIME_WAKEUP, SystemClock.elapsedRealtime() + AlarmManager.INTERVAL_DAY, pendingIntent
+            AlarmManager.ELAPSED_REALTIME_WAKEUP,
+            SystemClock.elapsedRealtime() + AlarmManager.INTERVAL_DAY,
+            pendingIntent
         )
         //Toast.makeText(context, "set Alarm on $hour : $minute", Toast.LENGTH_SHORT).show()
     }
 
     private fun makeNotification(context: Context) {
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channelId = "날씨 알림"
             val channelName = "PlaceList"
             val notificationChannel =
                 NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_DEFAULT)
-                    .apply{
+                    .apply {
                         enableLights(true)
                         lightColor = Color.BLUE
                         lockscreenVisibility = Notification.VISIBILITY_PRIVATE
@@ -138,19 +199,26 @@ class WeatherAlarmReceiver : BroadcastReceiver() {
             val intent = Intent(context, MainActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
             }
-            val pendingIntent: PendingIntent = PendingIntent.getActivity(context, 1000, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            val pendingIntent: PendingIntent = PendingIntent.getActivity(
+                context,
+                1000,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
 
             val notificationBuilder = NotificationCompat.Builder(context, channelId)
                 .setContentTitle("날씨 알림")
                 .setContentText("$stationName 예보 확인하기")
-                .setSmallIcon(R.drawable.baseline_alarm_24)
+                .setSmallIcon(R.drawable.img_p)
                 .setAutoCancel(true)
                 .setContentIntent(pendingIntent)
                 .setStyle(
                     NotificationCompat.BigTextStyle()
-                    .bigText(getWeatherForecastMsg()))
+                        .bigText(getWeatherForecastMsg())
+                )
             val notification = notificationBuilder.build()
-            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            val notificationManager =
+                context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             notificationManager.apply {
                 createNotificationChannel(notificationChannel)
                 notify(0, notification)
@@ -166,31 +234,40 @@ class WeatherAlarmReceiver : BroadcastReceiver() {
                 when (it?.fcstValue) {
                     "1" -> {
                         msg += getPtyMsg(it?.fcstDate, it?.fcstTime, "비")
+                        pFlag = true
                         return@forEach
                     }
                     "2" -> {
                         msg += getPtyMsg(it?.fcstDate, it?.fcstTime, "비/눈")
+                        pFlag = true
                         return@forEach
                     }
                     "3" -> {
                         msg += getPtyMsg(it?.fcstDate, it?.fcstTime, "눈")
+                        pFlag = true
                         return@forEach
                     }
                     "4" -> {
                         msg += getPtyMsg(it?.fcstDate, it?.fcstTime, "소나기")
+                        pFlag = true
                         return@forEach
                     }
                 }
             }
         }
+        if(!pFlag) msg += "24시간 이내 강수 예보 없음\n"
         msg += "오존 등급: ${measuredValue?.o3Grade.toString()}\n" +
                 "미세먼지 등급: ${measuredValue?.pm10Grade.toString()}\n" +
                 "초미세먼지 등급: ${measuredValue?.pm10Grade.toString()}\n"
         return msg
     }
 
-    private fun getPtyMsg(fcstDate: String?, fcstTime: String?, pty: String): String{
-        val today = if(fcstDate == getDate()) { "오늘" } else { "내일" }
+    private fun getPtyMsg(fcstDate: String?, fcstTime: String?, pty: String): String {
+        val today = if (fcstDate == getDate()) {
+            "오늘"
+        } else {
+            "내일"
+        }
         return "$today ${fcstTime}시에 $pty 예보가 있어요."
     }
 
@@ -255,19 +332,24 @@ class WeatherAlarmReceiver : BroadcastReceiver() {
         val pendingIntent = Intent(context, WeatherAlarmReceiver::class.java).let {
             it.putExtra("code", 1000)
             it.putExtra("hour", hour)
-            it.putExtra("minute",minute)
-            PendingIntent.getBroadcast(context, 1000, it, PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            it.putExtra("minute", minute)
+            PendingIntent.getBroadcast(
+                context,
+                1000,
+                it,
+                PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
         }
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
 
-        if(alarmOnOff) {
-            val calendar = Calendar.getInstance().apply{
+        if (alarmOnOff) {
+            val calendar = Calendar.getInstance().apply {
                 timeInMillis = System.currentTimeMillis()
                 set(Calendar.HOUR_OF_DAY, hour!!.toInt())
                 set(Calendar.MINUTE, minute!!.toInt())
             }
             //이미 지난 시간 설정한 경우 다음날 같은 시간으로 설정
-            if(calendar.before(Calendar.getInstance())) {
+            if (calendar.before(Calendar.getInstance())) {
                 calendar.add(Calendar.DATE, 1)
             }
             //alarmManager.setRepeating(AlarmManager.RTC_WAKEUP, calendar.timeInMillis, AlarmManager.INTERVAL_DAY, pendingIntent)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/airquality/AirQualityResponse.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/airquality/AirQualityResponse.kt
@@ -1,0 +1,9 @@
+package org.konkuk.placelist.weather.models.airquality
+
+
+import com.google.gson.annotations.SerializedName
+
+data class AirQualityResponse(
+    @SerializedName("response")
+    val response: Response?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/airquality/Body.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/airquality/Body.kt
@@ -1,0 +1,9 @@
+package org.konkuk.placelist.weather.models.airquality
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Body(
+    @SerializedName("items")
+    val measuredValues: List<MeasuredValue?>?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/airquality/Grade.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/airquality/Grade.kt
@@ -1,0 +1,22 @@
+package org.konkuk.placelist.weather.models.airquality
+
+import androidx.annotation.ColorRes
+import com.google.gson.annotations.SerializedName
+
+enum class Grade(val label: String) {
+
+    @SerializedName("1")
+    GOOD("좋음"),
+    @SerializedName("2")
+    NORMAL("보통"),
+    @SerializedName("3")
+    BAD("나쁨"),
+    @SerializedName("4")
+    AWFUL("매우 나쁨"),
+
+    UNKNOWN("미측정");
+
+    override fun toString(): String {
+        return "$label"
+    }
+}

--- a/app/src/main/java/org/konkuk/placelist/weather/models/airquality/Header.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/airquality/Header.kt
@@ -1,0 +1,11 @@
+package org.konkuk.placelist.weather.models.airquality
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Header(
+    @SerializedName("resultCode")
+    val resultCode: String?,
+    @SerializedName("resultMsg")
+    val resultMsg: String?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/airquality/MeasuredValue.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/airquality/MeasuredValue.kt
@@ -1,0 +1,60 @@
+package org.konkuk.placelist.weather.models.airquality
+
+
+import com.google.gson.annotations.SerializedName
+import org.konkuk.placelist.weather.models.airquality.Grade
+
+data class MeasuredValue(
+    @SerializedName("coFlag") // 일산화탄소 플래그
+    val coFlag: Any?,
+    @SerializedName("coGrade") // 일산화탄소 지수
+    val coGrade: Grade?,
+    @SerializedName("coValue") // 일산화탄소 농도
+    val coValue: String?,
+    @SerializedName("dataTime") // 측정일
+    val dataTime: String?,
+    @SerializedName("khaiGrade") // 통합 대기 환경 지수
+    val khaiGrade: Grade?,
+    @SerializedName("khaiValue") // 통합 대기 환경 수치
+    val khaiValue: String?,
+    @SerializedName("mangName") // 측정망 정보
+    val mangName: String?,
+    @SerializedName("no2Flag") // 이산화질소 플래그
+    val no2Flag: Any?,
+    @SerializedName("no2Grade") // 이산화질소 지수
+    val no2Grade: Grade?,
+    @SerializedName("no2Value") // 이산화질소 농도
+    val no2Value: String?,
+    @SerializedName("o3Flag") // 오존 플래그
+    val o3Flag: Any?,
+    @SerializedName("o3Grade") // 오존 지수
+    val o3Grade: Grade?,
+    @SerializedName("o3Value") // 오존 농도
+    val o3Value: String?,
+    @SerializedName("pm10Flag") // 미세먼지 플래그
+    val pm10Flag: Any?,
+    @SerializedName("pm10Grade") // 미세먼지  24시간 등급
+    val pm10Grade: Grade?,
+    @SerializedName("pm10Grade1h") // 미세먼지 1시간 등급
+    val pm10Grade1h: String?,
+    @SerializedName("pm10Value") // 미세먼지 농도
+    val pm10Value: String?,
+    @SerializedName("pm10Value24") // 미세먼지 24시간 예측 이동 농도
+    val pm10Value24: String?,
+    @SerializedName("pm25Flag") // 초미세먼지 플래그
+    val pm25Flag: Any?,
+    @SerializedName("pm25Grade") // 초미세먼지  24시간 등급
+    val pm25Grade: Grade?,
+    @SerializedName("pm25Grade1h") // 초미세먼지 1시간 등급
+    val pm25Grade1h: String?,
+    @SerializedName("pm25Value") // 초미세먼지 농도
+    val pm25Value: String?,
+    @SerializedName("pm25Value24") // 초미세먼지 24시간 예측 이동 농도
+    val pm25Value24: String?,
+    @SerializedName("so2Flag") // 이황산가스 플래그
+    val so2Flag: Any?,
+    @SerializedName("so2Grade") // 이황산가스 지수
+    val so2Grade: Grade?,
+    @SerializedName("so2Value") // 이황산가수 농도
+    val so2Value: String?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/airquality/Response.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/airquality/Response.kt
@@ -1,0 +1,11 @@
+package org.konkuk.placelist.weather.models.airquality
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Response(
+    @SerializedName("body")
+    val body: Body?,
+    @SerializedName("header")
+    val header: Header?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/monitoringstation/Body.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/monitoringstation/Body.kt
@@ -1,0 +1,9 @@
+package org.konkuk.placelist.weather.models.monitoringstation
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Body(
+    @SerializedName("items")
+    val monitoringStations: List<MonitoringStation?>?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/monitoringstation/Header.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/monitoringstation/Header.kt
@@ -1,0 +1,11 @@
+package org.konkuk.placelist.weather.models.monitoringstation
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Header(
+    @SerializedName("resultCode")
+    val resultCode: String?,
+    @SerializedName("resultMsg")
+    val resultMsg: String?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/monitoringstation/MonitoringStation.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/monitoringstation/MonitoringStation.kt
@@ -1,0 +1,13 @@
+package org.konkuk.placelist.weather.models.monitoringstation
+
+
+import com.google.gson.annotations.SerializedName
+
+data class MonitoringStation(
+    @SerializedName("addr")
+    val addr: String?,
+    @SerializedName("stationName")
+    val stationName: String?,
+    @SerializedName("tm")
+    val tm: Double?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/monitoringstation/MonitoringStationsResponse.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/monitoringstation/MonitoringStationsResponse.kt
@@ -1,0 +1,9 @@
+package org.konkuk.placelist.weather.models.monitoringstation
+
+
+import com.google.gson.annotations.SerializedName
+
+data class MonitoringStationsResponse(
+    @SerializedName("response")
+    val response: Response?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/monitoringstation/Response.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/monitoringstation/Response.kt
@@ -1,0 +1,11 @@
+package org.konkuk.placelist.weather.models.monitoringstation
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Response(
+    @SerializedName("body")
+    val body: Body?,
+    @SerializedName("header")
+    val header: Header?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/tmcoordinates/Document.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/tmcoordinates/Document.kt
@@ -1,0 +1,11 @@
+package org.konkuk.placelist.weather.models.tmcoordinates
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Document(
+    @SerializedName("x")
+    val x: Double?,
+    @SerializedName("y")
+    val y: Double?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/tmcoordinates/Meta.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/tmcoordinates/Meta.kt
@@ -1,0 +1,9 @@
+package org.konkuk.placelist.weather.models.tmcoordinates
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Meta(
+    @SerializedName("total_count")
+    val totalCount: Int?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/tmcoordinates/TmCoordinatesResponse.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/tmcoordinates/TmCoordinatesResponse.kt
@@ -1,0 +1,10 @@
+package org.konkuk.placelist.weather.models.tmcoordinates
+
+import com.google.gson.annotations.SerializedName
+
+data class TmCoordinatesResponse(
+    @SerializedName("documents")
+    val documents: List<Document?>?,
+    @SerializedName("meta")
+    val meta: Meta?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/weatherforecast/Body.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/weatherforecast/Body.kt
@@ -1,0 +1,11 @@
+package org.konkuk.placelist.weather.models.weatherforecast
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Body(
+    @SerializedName("dataType")
+    val dataType: String?,
+    @SerializedName("items")
+    val weatherForecasts: WeatherForecasts?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/weatherforecast/Header.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/weatherforecast/Header.kt
@@ -1,0 +1,11 @@
+package org.konkuk.placelist.weather.models.weatherforecast
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Header(
+    @SerializedName("resultCode")
+    val resultCode: String?,
+    @SerializedName("resultMsg")
+    val resultMsg: String?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/weatherforecast/Response.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/weatherforecast/Response.kt
@@ -1,0 +1,11 @@
+package org.konkuk.placelist.weather.models.weatherforecast
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Response(
+    @SerializedName("body")
+    val body: Body?,
+    @SerializedName("header")
+    val header: Header?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/weatherforecast/WeatherForecast.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/weatherforecast/WeatherForecast.kt
@@ -1,0 +1,23 @@
+package org.konkuk.placelist.weather.models.weatherforecast
+
+
+import com.google.gson.annotations.SerializedName
+
+data class WeatherForecast(
+    @SerializedName("baseDate")
+    val baseDate: String?,
+    @SerializedName("baseTime")
+    val baseTime: String?,
+    @SerializedName("category")
+    val category: String?,
+    @SerializedName("fcstDate")
+    val fcstDate: String?,
+    @SerializedName("fcstTime")
+    val fcstTime: String?,
+    @SerializedName("fcstValue")
+    val fcstValue: String?,
+    @SerializedName("nx")
+    val nx: Int?,
+    @SerializedName("ny")
+    val ny: Int?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/weatherforecast/WeatherForecastResponse.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/weatherforecast/WeatherForecastResponse.kt
@@ -1,0 +1,9 @@
+package org.konkuk.placelist.weather.models.weatherforecast
+
+
+import com.google.gson.annotations.SerializedName
+
+data class WeatherForecastResponse(
+    @SerializedName("response")
+    val response: Response?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/models/weatherforecast/WeatherForecasts.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/models/weatherforecast/WeatherForecasts.kt
@@ -1,0 +1,8 @@
+package org.konkuk.placelist.weather.models.weatherforecast
+
+import com.google.gson.annotations.SerializedName
+
+data class WeatherForecasts(
+    @SerializedName("item")
+    val weatherForecast: List<WeatherForecast?>?
+)

--- a/app/src/main/java/org/konkuk/placelist/weather/object/GpsConverter.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/object/GpsConverter.kt
@@ -1,0 +1,43 @@
+package org.konkuk.placelist.weather.`object`
+
+import android.graphics.Point
+
+object GpsConverter {
+
+    // 위경도를 기상청에서 사용하는 격자 좌표로 변환
+    fun dfsXyConv(v1: Double, v2: Double) : Point {
+        val RE = 6371.00877     // 지구 반경(km)
+        val GRID = 5.0          // 격자 간격(km)
+        val SLAT1 = 30.0        // 투영 위도1(degree)
+        val SLAT2 = 60.0        // 투영 위도2(degree)
+        val OLON = 126.0        // 기준점 경도(degree)
+        val OLAT = 38.0         // 기준점 위도(degree)
+        val XO = 43             // 기준점 X좌표(GRID)
+        val YO = 136            // 기준점 Y좌표(GRID)
+        val DEGRAD = Math.PI / 180.0
+        val re = RE / GRID
+        val slat1 = SLAT1 * DEGRAD
+        val slat2 = SLAT2 * DEGRAD
+        val olon = OLON * DEGRAD
+        val olat = OLAT * DEGRAD
+
+        var sn = Math.tan(Math.PI * 0.25 + slat2 * 0.5) / Math.tan(Math.PI * 0.25 + slat1 * 0.5)
+        sn = Math.log(Math.cos(slat1) / Math.cos(slat2)) / Math.log(sn)
+        var sf = Math.tan(Math.PI * 0.25 + slat1 * 0.5)
+        sf = Math.pow(sf, sn) * Math.cos(slat1) / sn
+        var ro = Math.tan(Math.PI * 0.25 + olat * 0.5)
+        ro = re * sf / Math.pow(ro, sn)
+
+        var ra = Math.tan(Math.PI * 0.25 + (v1) * DEGRAD * 0.5)
+        ra = re * sf / Math.pow(ra, sn)
+        var theta = v2 * DEGRAD - olon
+        if (theta > Math.PI) theta -= 2.0 * Math.PI
+        if (theta < -Math.PI) theta += 2.0 * Math.PI
+        theta *= sn
+
+        val x = (ra * Math.sin(theta) + XO + 0.5).toInt()
+        val y = (ro - ra * Math.cos(theta) + YO + 0.5).toInt()
+
+        return Point(x, y)
+    }
+}

--- a/app/src/main/java/org/konkuk/placelist/weather/object/Url.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/object/Url.kt
@@ -1,0 +1,6 @@
+package org.konkuk.placelist.weather.`object`
+
+object Url {
+    const val KAKAO_API_BASE_URL = "https://dapi.kakao.com/"
+    const val PUBLIC_DATA_BASE_URL = "http://apis.data.go.kr/"
+}

--- a/app/src/main/java/org/konkuk/placelist/weather/services/AirKoreaApiService.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/services/AirKoreaApiService.kt
@@ -1,0 +1,28 @@
+package org.konkuk.placelist.weather.services
+
+import org.konkuk.placelist.BuildConfig.PUBLIC_DATA_SERVICE_KEY
+import org.konkuk.placelist.weather.models.airquality.AirQualityResponse
+import org.konkuk.placelist.weather.models.monitoringstation.MonitoringStationsResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface AirKoreaApiService {
+
+    @GET("B552584/MsrstnInfoInqireSvc/getNearbyMsrstnList" +
+            "?serviceKey=${PUBLIC_DATA_SERVICE_KEY}" +
+            "&returnType=json")
+    suspend fun getNearbyMonitoringStation(
+        @Query("tmX") tmX: Double,
+        @Query("tmY") tmY: Double
+    ): Response<MonitoringStationsResponse>
+
+    @GET("B552584/ArpltnInforInqireSvc/getMsrstnAcctoRltmMesureDnsty" +
+            "?serviceKey=${PUBLIC_DATA_SERVICE_KEY}" +
+            "&returnType=json" +
+            "&dataTerm=DAILY" +
+            "&ver=1.3")
+    suspend fun getRealtimeAirQualities(
+        @Query("stationName") stationName: String
+    ): Response<AirQualityResponse>
+}

--- a/app/src/main/java/org/konkuk/placelist/weather/services/KakaoLocalApiService.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/services/KakaoLocalApiService.kt
@@ -1,0 +1,18 @@
+package org.konkuk.placelist.weather.services
+
+import org.konkuk.placelist.BuildConfig.KAKAO_API_KEY
+import org.konkuk.placelist.weather.models.tmcoordinates.TmCoordinatesResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.Query
+
+interface KakaoLocalApiService {
+
+    @Headers("Authorization: KakaoAK $KAKAO_API_KEY")
+    @GET("v2/local/geo/transcoord.json?output_coord=TM")
+    suspend fun getTmCoordinates(
+        @Query("x") longitude: Double,
+        @Query("y") latitude: Double
+    ): Response<TmCoordinatesResponse>
+}

--- a/app/src/main/java/org/konkuk/placelist/weather/services/KmaApiService.kt
+++ b/app/src/main/java/org/konkuk/placelist/weather/services/KmaApiService.kt
@@ -1,0 +1,19 @@
+package org.konkuk.placelist.weather.services
+
+import org.konkuk.placelist.BuildConfig.PUBLIC_DATA_SERVICE_KEY
+import org.konkuk.placelist.weather.models.weatherforecast.WeatherForecastResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface KmaApiService {
+
+    @GET("1360000/VilageFcstInfoService_2.0/getVilageFcst" + "?serviceKey=${PUBLIC_DATA_SERVICE_KEY}" + "&returnType=json" + "&numOfRows=290")
+    suspend fun getWeatherForecasts(
+        @Query("base_date") base_date: String,
+        @Query("base_time") base_time: String,
+        @Query("dataType") dataType: String,
+        @Query("nx") x: Int,
+        @Query("ny") y: Int
+    ): Response<WeatherForecastResponse>
+}

--- a/app/src/main/res/drawable/baseline_alarm_24.xml
+++ b/app/src/main/res/drawable/baseline_alarm_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M22,5.72l-4.6,-3.86 -1.29,1.53 4.6,3.86L22,5.72zM7.88,3.39L6.6,1.86 2,5.71l1.29,1.53 4.59,-3.85zM12.5,8L11,8v6l4.75,2.85 0.75,-1.23 -4,-2.37L12.5,8zM12,4c-4.97,0 -9,4.03 -9,9s4.02,9 9,9c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9zM12,20c-3.87,0 -7,-3.13 -7,-7s3.13,-7 7,-7 7,3.13 7,7 -3.13,7 -7,7z"/>
+</vector>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -3,12 +3,12 @@
     <PreferenceCategory android:title="알림 설정">
         <SwitchPreference
             android:defaultValue="true"
-            android:key="weather"
+            android:key="weatherAlarm"
             android:summary="날씨 알림을 받으려면 체크하세요"
             android:title="날씨 알림" />
         <Preference
-            android:dependency="weather"
-            android:key="weather_notification"
+            android:dependency="weatherAlarm"
+            android:key="weatherTimer"
             android:selectable="true"
             android:summary="날씨 알림을 받을 시간을 설정해 주세요"
             android:title="날씨 알림 시간 설정" />


### PR DESCRIPTION
## 개요 🧾
설정에서 정한 시간에 맞게 날씨 알림을 받습니다.
현재 유의미하다고 생각되는 데이터 정보들로 알림 메시지를 보여주도록 구현하였습니다.
날씨와 미세먼지 정보는 알림을 받을 때 사용자가 위치한 곳의 예보를 알려주는 것이 맞다고 판단하여 그때그때 위치 정보를 요청하도록 하였습니다.

날씨 예보는 사용자가 설정한 시간으로부터 가장 최근에 업데이트된 예보 정보를 1일치 가져옵니다. 
ex) 7시 알림 설정 -> 가장 최근에 업데이트된 6시 예보 정보 -> 다음날 6시까지의 날씨 정보를 가져옴

미세먼지 정보는 가장 가까운 관측소로부터 가져옵니다.
현재 위치 계산 -> 가장 가까운 관측소에 해당하는 미세먼지 정보 요청

메시지 내용)
강수 정보 있을 경우 -> 오늘 or 내일 몇시에 강수 예보가 있는지
오존 정보
미세먼지 정보
초미세먼지 정보


## 주의사항 ⚠
설정에서 날씨 알림 시간을 드래그하지 않고 직접 값을 입력하여 시간이나 분 정보를 설정할때 입력하는 도중에 체크버튼을 누르면 Settings 값이 변하지 않습니다. 
정확히 드래그하거나 값을 직접 입력하는 경우에는 키패드의 엔터를 누르고 체크 버튼을 눌러야 정상적으로 변경됩니다.

안드로이드에서 제공하는 alarmManager의 알림 시간이 생각보다 부정확합니다. 여러가지 경우를 테스트하여 그나마 가장 정확한 알림을 제공하는 것으로 구현하였습니다. 정시에 알림이 오지 않는 경우 1~2분 정도 기다리면 보통 알림이 옵니다.
