### PR TITLE
feat: Todo 반복 요일 추가, 장소 삭제 시 전체 삭제 (알림 창 구현)

### DIFF
--- a/app/src/main/java/org/konkuk/placelist/domain/Todo.kt
+++ b/app/src/main/java/org/konkuk/placelist/domain/Todo.kt
@@ -3,14 +3,17 @@ package org.konkuk.placelist.domain
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.ForeignKey.Companion.CASCADE
 import androidx.room.PrimaryKey
 import org.konkuk.placelist.domain.enums.PlaceSituation
 import org.konkuk.placelist.domain.enums.TodoPriority
+import java.io.Serializable
 
 @Entity(tableName = "todos",
     foreignKeys = [ForeignKey(entity = Place::class,
         parentColumns = ["place_id"],
-        childColumns = ["place_id"] )]
+        childColumns = ["place_id"],
+        onDelete = CASCADE)],
 )
 
 data class Todo(
@@ -22,7 +25,8 @@ data class Todo(
     var priority: TodoPriority,
 //    var subtasks: List<Subtask>,
 
+    var repeatDays: Int,
+
     // About Places
-    var situation: PlaceSituation,
-    var detectRange: Double = 0.0
-)
+    var situation: PlaceSituation
+) : Serializable

--- a/app/src/main/java/org/konkuk/placelist/main/MainActivity.kt
+++ b/app/src/main/java/org/konkuk/placelist/main/MainActivity.kt
@@ -99,12 +99,23 @@ class MainActivity : AppCompatActivity(), AddPlaceListener {
             }
 
             override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
-                CoroutineScope(Dispatchers.IO).launch{
-                    db.placesDao().delete(placeAdapter.items[viewHolder.adapterPosition])
-                    withContext(Dispatchers.Main) {
-                        placeAdapter.removeItem(viewHolder.adapterPosition)
+                AlertDialog.Builder(this@MainActivity)
+                    .setTitle("장소 삭제")
+                    .setMessage("장소 내 할 일이 모두 삭제됩니다.\n정말 삭제하시겠어요?")
+                    .setPositiveButton("삭제"){_, _ ->
+                        CoroutineScope(Dispatchers.IO).launch{
+                            db.placesDao().delete(placeAdapter.items[viewHolder.adapterPosition])
+                            withContext(Dispatchers.Main) {
+                                placeAdapter.removeItem(viewHolder.adapterPosition)
+                            }
+                        }
                     }
-                }
+                    .setNegativeButton("취소"){d, _ ->
+                        placeAdapter.refresh()
+                        d.dismiss()
+                    }
+                    .create()
+                    .show()
             }
         }
         val itemTouchHelper = ItemTouchHelper(simpleCallback)

--- a/app/src/main/java/org/konkuk/placelist/place/PlacesActivity.kt
+++ b/app/src/main/java/org/konkuk/placelist/place/PlacesActivity.kt
@@ -1,7 +1,6 @@
 package org.konkuk.placelist.place
 
 import android.os.Bundle
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -40,9 +39,9 @@ class PlacesActivity : AppCompatActivity(), AddTodoListener, AddPlaceListener {
             todoAdapter = TodoAdapter(db, items, place.id)
             todoAdapter.itemClickListener = object : TodoAdapter.OnItemClickListener {
                 override fun onItemClick(data: Todo, pos: Int) {
-                    Toast.makeText(this@PlacesActivity,
-                        data.name,
-                        Toast.LENGTH_SHORT).show()
+                    // 수정은 여기에서 진행해야 함
+                    // DialogFragment으로 Todo 넘겨주기
+                    AddTodoDialogFragment.toInstance(data).show(supportFragmentManager, "EditTodo")
 
                 }
             }

--- a/app/src/main/java/org/konkuk/placelist/place/TodoAdapter.kt
+++ b/app/src/main/java/org/konkuk/placelist/place/TodoAdapter.kt
@@ -1,6 +1,5 @@
 package org.konkuk.placelist.place
 
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
@@ -58,11 +57,8 @@ class TodoAdapter(private val db: PlacesListDatabase, var items : ArrayList<Todo
         CoroutineScope(Dispatchers.IO).launch{
             db.TodoDao().insert(todo)
             items = db.TodoDao().findTodoByPlaceId(placeId) as ArrayList<Todo>
-            for(i in items){
-                Log.i("ITEM", i.name)
-            }
             withContext(Dispatchers.Main){
-                notifyItemInserted(items.size)
+                notifyItemRangeChanged(0, items.size)
             }
         }
     }


### PR DESCRIPTION
## 개요 🧾
<!-- 이곳에 PR의 내용을 간단하게 작성해주세요. -->
이제 장소 삭제 시 안에 Todo가 있더라도 충돌이 일어나지 않습니다. 단, 알림창을 통해 사용자의 의사를 한 번 더 묻습니다
Todo 수정하는 부분을 구현했습니다.

## 변경사항 🛠
<!-- 이곳에 코드 변경 사항이나 추가된 사항에 대해서 작성해주세요. -->
Todo를 요일별 반복하는 건 납득이 되는데, 시간 사항을 어떻게 넣어야할지는 회의를 더 진행해보아야 할 것 같아요

## 주의사항 ⚠
<!-- 이곳에 리뷰어에게 할 말이나, 주의해야 하는 점에 대해서 작성해 주세요 -->
작동 확인해주세요
토금목수화월일 와 같이 비트가 설정됩니다. 예) 1001010 -> 월수토 반복 (2진수)
따라서 1 shl i (i = 0 to 6) -> 일 ~ 토요일 순서입니다.
DB구조 변경에 따라 기존에 설치된 것 실행하시면 충돌이 일어나니 재설치해 주세요~