### PR TITLE
fix: 확대 후 위치 재선정시 축소되는 것 수정

### DIFF
--- a/app/src/main/java/org/konkuk/placelist/main/AddPlaceDialogFragment.kt
+++ b/app/src/main/java/org/konkuk/placelist/main/AddPlaceDialogFragment.kt
@@ -15,6 +15,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.SeekBar
+import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
@@ -102,13 +103,19 @@ class AddPlaceDialogFragment : DialogFragment() {
             this.submitBtn.setOnClickListener {
                 var placeId = 0
                 if (place != null) placeId = place!!.id
-                val pos = model.location.value!!
-                addPlaceListener.addPlace(placeId,
-                    binding.placename.text.toString(),
-                    pos.latitude.toString(),
-                    pos.longitude.toString(),
-                    model.detectRange.value!!)
-                dismiss()
+                if(model.location.value!=null) {
+                    val pos = model.location.value!!
+                    addPlaceListener.addPlace(
+                        placeId,
+                        binding.placename.text.toString(),
+                        pos.latitude.toString(),
+                        pos.longitude.toString(),
+                        model.detectRange.value!!
+                    )
+                    dismiss()
+                }else {
+                    Toast.makeText(requireContext(),"장소가 선택되지 않았습니다.", Toast.LENGTH_SHORT).show()
+                }
             }
         }
 

--- a/app/src/main/java/org/konkuk/placelist/main/MapFragment.kt
+++ b/app/src/main/java/org/konkuk/placelist/main/MapFragment.kt
@@ -114,7 +114,11 @@ class MapFragment : Fragment(), OnMapReadyCallback {
             mMap.clear()
             marker = mMap.addMarker(markerOptions.position(it))
             mMap.addCircle(circleOptions.center(it).radius(radius))
-            mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(marker!!.position, 15.0f))
+            if(mMap.cameraPosition.zoom>=15.0f) {
+                mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(marker!!.position, mMap.cameraPosition.zoom))
+            }else {
+                mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(marker!!.position, 15.0f))
+            }
         }
 
         mMap.setOnMapClickListener {
@@ -123,7 +127,11 @@ class MapFragment : Fragment(), OnMapReadyCallback {
             marker = mMap.addMarker(markerOptions.position(it))
             mMap.addCircle(circleOptions.center(it).radius(radius))
             model.setLiveData(it)
-            mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(marker!!.position, 15.0f))
+            if(mMap.cameraPosition.zoom>=15.0f) {
+                mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(marker!!.position, mMap.cameraPosition.zoom))
+            }else {
+                mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(marker!!.position, 15.0f))
+            }
         }
 
         if (ActivityCompat.checkSelfPermission(


### PR DESCRIPTION


## 개요 🧾
장소 선택 전 추가버튼 클릭 시 오류 수정
장소  추가 시 맵 확대 후 장소 변경 시 맵이 축소되는 상황 수정 


## 변경사항 🛠
장소 선택 전 추가버튼 클릭 시 토스트 메시지 뜨게 해놨습니다.
맵 확대 후 장소 변경 시 기존 수치보다 확대되어 있는 경우 확대된 상태 유지되도록 변경했습니다.

## 주의사항 ⚠
<!-- 이곳에 리뷰어에게 할 말이나, 주의해야 하는 점에 대해서 작성해 주세요 -->
