### PR TITLE
fix: 반복요일이 있을 때, 수정 시 Switch가 활성화되지 않는 현상 수정

### DIFF
--- a/app/src/main/java/org/konkuk/placelist/place/AddTodoDialogFragment.kt
+++ b/app/src/main/java/org/konkuk/placelist/place/AddTodoDialogFragment.kt
@@ -46,6 +46,7 @@ class AddTodoDialogFragment : DialogFragment() {
                 arguments?.getSerializable("todo", Todo::class.java)!!
             else arguments?.getSerializable("todo") as Todo
             binding.todoname.setText(todo?.name)
+            binding.repeatSwitch.isChecked = todo?.repeatDays != 0
             binding.outToggleBtn.isChecked = (todo?.situation == PlaceSituation.BOTH) or (todo?.situation == PlaceSituation.ESCAPE)
             binding.inToggleButton.isChecked = (todo?.situation == PlaceSituation.BOTH) or (todo?.situation == PlaceSituation.ENTER)
             val array = arrayOf(binding.sun, binding.mon, binding.tue, binding.wed, binding.thu, binding.fri, binding.sat)


### PR DESCRIPTION
## 개요 🧾
<!-- 이곳에 PR의 내용을 간단하게 작성해주세요. -->
![image](https://github.com/konkuk-PlaceList/PlaceList/assets/31026350/2f7ffebe-6f10-4217-a90e-ea8c4018bf9e)

## 변경사항 🛠
<!-- 이곳에 코드 변경 사항이나 추가된 사항에 대해서 작성해주세요. -->
수정했어요~

스위치를 켠 뒤, 아무것도 체크하지 않고 저장 시에는 이후 수정 시 스위치가 꺼진 채로 열립니다. (반복 없음은 매일 반복과 같아요)
